### PR TITLE
HT-411 - make u4u_util pip install-able from other repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "u4u_util"
+version = "0.0.1"
+dependencies = [
+  "boto3",
+  "civis<=1.16.0",
+  "joblib<=1.2",
+  "numpy",
+  "paramiko",
+  "pandas==2.0.2",
+  # "psycopg2",  fails if pg not installed
+  "typing_extensions",
+]
+requires-python = ">=3.10"
+authors = [
+  {name = "Katie Harris", email = "katie@unrefugees.org"},
+  {name = "Andrew Cheng", email = "acheng@usaforunhcr.org"},
+  {name = "Alfred Lee", email = "alfred@unrefugees.org"},
+]
+description = "custom, private utilities for USA for UNHCR"
+readme = "README.md"


### PR DESCRIPTION
The intention with this PR is to allow pip-installing `u4u_util`. This allows tracking this repo as a git submodule in `Modeling` (and anywhere else), and calling modules with patterns like the following:

```python
from Utils import alerts

alerts.create_email(...)
```

Notes about the contents:

`build-system` is sort of irrelevant since we're not building. I took the dependency list from the `Pipfile` in this repo. I think `pipenv` is fine to use for development, but for installing as a library, I couldn't find a way to tell pipenv to read the `Pipfile` without making a new virtual environment.

I made two changes to the dependencies to make it compatible with `Modeling` (i.e., so pipenv installing doesn't fail):
* pinned `pandas` to 2.0.2 (in Pipenv, it's pinned <= 2.0.0)
* skipped `psycopg2` (`Modeling` won't use it, and maybe nothing will after we leave Civis. The issue is that it requires postgres to be installed on the system to succeed, and I don't want to install that locally if I'm not going to run it.)

Testing:
* I tested that I can do a fresh `pipenv install` in the `Modeling` repo
  * added this repo as a git submodule under `Modeling/src/`
  * added this line to the `Pipfile` in `Modeling`: `u4u-util = {file = "src/u4u_util", editable = true}`
* I tested that I can import all modules except `transferDBs3`, the only one that relies on `psycopg2`

To Do:
* Will open a PR in `Modeling` to pull this repo as a submodule. I have to do this after this PR is merged so that it syncs a working repo. Right now, `pipenv install` only works because I copied in the `pyproject.toml` file without committing it.
* If warranted, I can add developer notes to the readme here that every PR should bump the version numbers in `pyproject.toml` and any edits to `Pipfile` should also be made to the dependency list in `pyproject.toml`