### PR TITLE
HT-411 - add basic GCP functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # u4u_util
 U4U code utility library
+
+# Environments
+Users can specify the sets of credentials/secrets to use and the GCP project to connect to.
+Set the environment variable `ENV` and use `secrets` to fetch secrets by key.
+Environment identifiers are case insensitive.
+
+* `DEV_BST`:
+    * valid env var values: `DEVB`, `DEV_B`, `DEV_BST`
+    * connect to BST dev project
+    * use secrets read from local environment, including local user GCP creds
+* `DEV_HIVE`:
+    * valid env var values: `DEVH`, `DEV_H`, `DEV_HIVE`
+    * connect to HIVE dev project
+    * use secrets read from local environment, including local user GCP creds
+* `ANALYTICS`:
+    * valid env var values: `ANA`, `ANALYTICS`
+    * connect to PROD project
+    * use secrets read from local environment, including local user GCP creds
+    * user accounts have restricted access to tables and buckets in PROD
+* `STAGING`:
+    * valid env var values: `STG`, `STAGING`
+    * connect to STAGING project
+    * use secrets read from Google Secret Manager, including staging service account GCP creds
+    * keys must be prefixed with `STG_`
+    * [open question: where to fetch creds to connect to GSM? which creds?]
+* `PROD`:
+    * valid env var values: `PROD`, `PRODUCTION`
+    * connect to PROD project
+    * use secrets read from Google Secret Manager, including production service account GCP creds
+    * keys must be prefixed with `PROD_`
+    * [open question: where to fetch creds to connect to GSM? which creds?]

--- a/Utils/gbq.py
+++ b/Utils/gbq.py
@@ -1,0 +1,97 @@
+"""Facilitate connection to Google BigQuery"""
+
+import logging
+from types import ModuleType
+
+import pandas as pd
+from google.cloud import bigquery
+from google.cloud.bigquery import dbapi
+import pydata_google_auth
+import pandas_gbq as pdgbq
+
+from .secrets import SecretManager
+
+SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class GBQConnection:
+    def __init__(self, env: str = None):
+        # TODO: use another auth flow for non-local envs
+        self.creds = pydata_google_auth.get_user_credentials(SCOPES, auth_local_webserver=True)
+        self.secrets = SecretManager(env)
+        self.project_id = self.secrets.get_project_id()
+
+    def __connect(self):
+        client = bigquery.Client(credentials=self.creds, project=self.project_id)
+        return dbapi.Connection(client=client)
+
+    def runDDL(self, sqlScript: str):
+        conn = self.__connect()
+        cur = conn.cursor()
+        logging.debug(sqlScript[:250] + "...")
+        cur.execute(sqlScript)
+        conn.commit()
+        logging.info(f"{cur.rowcount} rows were affected")
+        cur.close()
+        conn.close()
+
+    def tryDDL(self, sqlScript: str):
+        conn = self.__connect()
+        try:
+            cur = conn.cursor()
+            logging.debug(sqlScript[:250] + "...")
+            cur.execute(sqlScript)
+            conn.commit()
+            logging.info(f"{cur.rowcount} rows were affected")
+            cur.close()
+            conn.close()
+        except Exception as e:
+            logging.error(e)
+
+    def getTableSchema(self, tableName: str, schemaName: str = "ds_salesforce"):
+        """
+        Returns schema of given table as data frame.
+            Parameters:
+                table_name (str): name of table to check.
+                schemaName (str): schema to create the table under (default is staging)
+            Returns:
+                (dataframe) dataframe of columns, and data type for table
+        """
+        ds_sf_col_sql = f"""SELECT COLUMN_NAME, DATA_TYPE
+        FROM {schemaName}.INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_NAME = '{tableName.lower()}';"""
+
+        return self.runQuery(ds_sf_col_sql)
+
+    def getTablesBySchema(self, schemaName: str):
+        """
+        Gets list of tables given a schema name.
+            Parameters:
+                schemaName (str): schema to query for tables
+            Returns:
+                list of table names in the schema
+        """
+        sqlQuery = f"""SELECT DISTINCT table_schema,table_name
+        FROM {schemaName}.information_schema.tables
+        ORDER BY table_name"""
+
+        schemaTables = self.runQuery(sqlQuery)
+
+        tablesList = schemaTables["table_name"].tolist()
+
+        return tablesList
+
+    def runQuery(self, query: str) -> pd.DataFrame:
+        conn = self.__connect()
+        logging.debug(query[:250])
+        return pd.read_sql(query, conn)
+
+
+def pandas_gbq(env: str = None) -> ModuleType:
+    creds = pydata_google_auth.get_user_credentials(SCOPES, auth_local_webserver=True)
+    pdgbq.context.credentials = creds
+
+    secrets = SecretManager(env)
+    assert secrets.is_local_env, "pandas_gbq only intended for local use"
+    pdgbq.context.project = secrets.get_project_id()
+    return pdgbq

--- a/Utils/gbq.py
+++ b/Utils/gbq.py
@@ -81,10 +81,10 @@ class GBQConnection:
 
         return tablesList
 
-    def runQuery(self, query: str) -> pd.DataFrame:
+    def runQuery(self, query: str, **kwargs) -> pd.DataFrame:
         conn = self.__connect()
         logging.debug(query[:250])
-        return pd.read_sql(query, conn)
+        return pd.read_sql(query, conn, **kwargs)
 
 
 def pandas_gbq(env: str = None) -> ModuleType:

--- a/Utils/gbq.py
+++ b/Utils/gbq.py
@@ -15,11 +15,12 @@ SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 
 
 class GBQConnection:
-    def __init__(self, env: str = None):
+    def __init__(self, env: str = None, project_id: str = None):
+        assert (env is None) or (project_id is None), "do not specify both `env` and `project_id`"
         # TODO: use another auth flow for non-local envs
         self.creds = pydata_google_auth.get_user_credentials(SCOPES, auth_local_webserver=True)
         self.secrets = SecretManager(env)
-        self.project_id = self.secrets.get_project_id()
+        self.project_id = project_id or self.secrets.project_id
 
     def __connect(self):
         client = bigquery.Client(credentials=self.creds, project=self.project_id)
@@ -87,11 +88,12 @@ class GBQConnection:
         return pd.read_sql(query, conn, **kwargs)
 
 
-def pandas_gbq(env: str = None) -> ModuleType:
+def pandas_gbq(env: str = None, project_id: str = None) -> ModuleType:
+    assert (env is None) or (project_id is None), "do not specify both `env` and `project_id`"
     creds = pydata_google_auth.get_user_credentials(SCOPES, auth_local_webserver=True)
     pdgbq.context.credentials = creds
 
     secrets = SecretManager(env)
     assert secrets.is_local_env, "pandas_gbq only intended for local use"
-    pdgbq.context.project = secrets.get_project_id()
+    pdgbq.context.project = project_id or secrets.project_id
     return pdgbq

--- a/Utils/secrets.py
+++ b/Utils/secrets.py
@@ -1,0 +1,91 @@
+""" fetch secrets by key from appropriate source according to environment """
+
+from enum import Enum
+import os
+
+
+TEAM_PREFIXES = {"HIVE", "BST"}
+
+
+class Env(Enum):
+    """ values are the key prefixes used in Secret Manager """
+    DEV = "DEV"
+    ANALYTICS = "ANA"
+    BILLING = "BILL"
+    STAGING = "STG"
+    PROD = "PROD"
+
+
+class SecretManager():
+    local_envs = {Env.DEV, Env.ANALYTICS}
+
+    def __init__(self, env: str = None):
+        if env is None:
+            env = os.environ.get("ENV", "dev")
+        self.env = Env[env.upper()]
+        self.is_local_env = self.env in self.local_envs
+
+    def _make_full_key(self, key: str) -> str:
+        """
+        prepend the environment to the key
+
+        @param key: the name of the secret with format {team}_{secret_name}
+        @return: name of the secret in Secret Manager with format {env}_{team}_{secret_name}
+        """
+        return f"{self.env.value}_{key}"
+
+    def _get_from_secret_manager(self, key: str, strict: bool) -> str:
+        """
+        read secret from Secret Manager
+
+        @param key: the name of the secret with format {team}_{secret_name}
+        @param strict: if False, return None if key does not exist, else raise
+        @return: value of secret from Secret Manager
+        """
+        # TODO: implement
+        # full_key = self._make_full_key(key)
+        # check for existence, raise if strict, else return None
+        # client = _make_secret_manager_client(...)
+        # fetch and return secret
+        # TODO: permit specifying secret version instead of always the latest
+        raise NotImplementedError
+
+    def _get_from_env(self, key: str, strict: bool) -> str:
+        """
+        read secret from local environment variables
+
+        @param key: the name of the secret with format {team}_{secret_name}
+        @param strict: if False, return None if key does not exist, else raise
+        @return: value of secret from local environment variables
+        """
+        if strict:
+            return os.environ[key]
+        else:
+            return os.environ.get(key)
+
+    def get(self, key: str, strict: bool = True) -> str:
+        """
+        Retrieve a secret by key, raise on missing key if strict.
+        Fetches from Secret Manager or local environment variables as appropriate
+        according to the environment. Input key converted to ALLCAPS before use.
+
+        @param key: the name of the secret with format {team}_{secret_name}
+        @param strict: if False, return None if key does not exist, else raise
+        @return: value of secret
+        """
+        key_normalized = key.upper()
+
+        assert any(
+            key_normalized.startswith(pre) for pre in TEAM_PREFIXES
+        ), "secret key must be prefixed with team"
+        # TODO: check key format
+
+        if self.is_local_env:
+            return self._get_from_env(key_normalized, strict)
+        else:
+            return self._get_from_secret_manager(key_normalized, strict)
+
+
+def _make_secret_manager_client():
+    """ authenticate and construct a SecretManagerServiceClient object """
+    pass

--- a/Utils/secrets.py
+++ b/Utils/secrets.py
@@ -5,6 +5,13 @@ import os
 
 
 TEAM_PREFIXES = {"HIVE", "BST"}
+PROJECT_IDS = {
+    "DEV": "amazing-city-422521-t1",
+    "ANA": "ana",
+    "BILL": "bill",
+    "STG": "stg",
+    "PROD": "prod",
+}
 
 
 class Env(Enum):
@@ -18,6 +25,7 @@ class Env(Enum):
 
 class SecretManager():
     local_envs = {Env.DEV, Env.ANALYTICS}
+    project_ids = {env: PROJECT_IDS[env.value] for env in Env}
 
     def __init__(self, env: str = None):
         if env is None:
@@ -84,6 +92,16 @@ class SecretManager():
             return self._get_from_env(key_normalized, strict)
         else:
             return self._get_from_secret_manager(key_normalized, strict)
+
+    def get_project_id(self, env: str = None) -> str:
+        """
+        Get the project_id for an environment
+
+        @param env: optional, name of an environment, case insensitive
+        @return: project_id
+        """
+        env = self.env if env is None else Env[env.upper()]
+        return self.project_ids[env]
 
 
 def _make_secret_manager_client():

--- a/Utils/secrets.py
+++ b/Utils/secrets.py
@@ -62,6 +62,7 @@ class SecretManager():
                 env = os.environ["ENV"]
         self.env = self._get_env(env)
         self.is_local_env = self.env in self.local_envs
+        self.project_id = self._get_project_id(env)
 
     def _get_env(self, env: str) -> Env:
         """
@@ -135,7 +136,7 @@ class SecretManager():
         else:
             return self._get_from_secret_manager(key_normalized, strict)
 
-    def get_project_id(self, env: str = None) -> str:
+    def _get_project_id(self, env: str = None) -> str:
         """
         Get the project_id for an environment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "u4u_util"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
   "boto3",
   "civis<=1.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
   "pandas==2.0.2",
   # "psycopg2",  fails if pg not installed
   "typing_extensions",
+  "google-cloud-bigquery==3.25.0",
+  "pydata-google-auth==1.8.2",
+  "pandas-gbq==0.23.1",
+  "tqdm",
 ]
 requires-python = ">=3.10"
 authors = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -2,7 +2,7 @@
 
 import os
 import pytest
-from Utils.secrets import Env, SecretManager
+from Utils.secrets import PROJECT_IDS, Env, SecretManager
 
 
 class TestSecretManager:
@@ -110,3 +110,23 @@ class TestSecretManager:
         # TODO: test malformed keys
 
         del os.environ[good_key.upper()]
+
+    def test_get_project_id(self):
+        """ test correct retrieval of project IDs """
+        sm_local = SecretManager("dev")
+        sm_prod = SecretManager("prod")
+
+        assert sm_local.get_project_id() == PROJECT_IDS["DEV"]
+        assert sm_prod.get_project_id() == PROJECT_IDS["PROD"]
+
+        for env_str, pid in [
+            ("dev", PROJECT_IDS["DEV"]),
+            ("DEV", PROJECT_IDS["DEV"]),
+            ("analytics", PROJECT_IDS["ANA"]),
+            ("Analytics", PROJECT_IDS["ANA"]),
+            ("billing", PROJECT_IDS["BILL"]),
+            ("staging", PROJECT_IDS["STG"]),
+            ("prod", PROJECT_IDS["PROD"]),
+        ]:
+            assert sm_local.get_project_id(env_str) == pid
+            assert sm_prod.get_project_id(env_str) == pid

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -141,8 +141,8 @@ class TestSecretManager:
         sm_local = SecretManager("devb")
         sm_prod = SecretManager("prod")
 
-        assert sm_local.get_project_id() == PROJECT_IDS[ENV_DEV_BST]
-        assert sm_prod.get_project_id() == PROJECT_IDS[ENV_PROD]
+        assert sm_local._get_project_id() == PROJECT_IDS[ENV_DEV_BST]
+        assert sm_prod._get_project_id() == PROJECT_IDS[ENV_PROD]
 
         for env_str, pid in [
             ("devb", PROJECT_IDS[ENV_DEV_BST]),
@@ -151,5 +151,5 @@ class TestSecretManager:
             ("staging", PROJECT_IDS[ENV_STAGING]),
             ("prod", PROJECT_IDS[ENV_PROD]),
         ]:
-            assert sm_local.get_project_id(env_str) == pid
-            assert sm_prod.get_project_id(env_str) == pid
+            assert sm_local._get_project_id(env_str) == pid
+            assert sm_prod._get_project_id(env_str) == pid

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,112 @@
+""" tests for Secret Manager utils """
+
+import os
+import pytest
+from Utils.secrets import Env, SecretManager
+
+
+class TestSecretManager:
+    def test_init(self):
+        """ ensure it reads environments properly and errors on others """
+        env_init = os.environ.get("ENV")
+        if "ENV" in os.environ:
+            del os.environ["ENV"]
+
+        # test reading each env, case insensitivity
+        for key, env, is_local_env in [
+            (None, Env.DEV, True),
+            ("dev", Env.DEV, True),
+            ("DEV", Env.DEV, True),
+            ("analytics", Env.ANALYTICS, True),
+            ("Analytics", Env.ANALYTICS, True),
+            ("billing", Env.BILLING, False),
+            ("staging", Env.STAGING, False),
+            ("prod", Env.PROD, False),
+        ]:
+            sm = SecretManager(key)
+            assert sm.env == env
+            assert sm.is_local_env == is_local_env
+
+        # test reading env var when env not supplied
+        os.environ["ENV"] = "dev"
+        sm = SecretManager()
+        assert sm.env is Env.DEV
+        assert sm.is_local_env
+
+        # test error with bad env
+        with pytest.raises(KeyError):
+            sm = SecretManager("other")
+
+        if env_init is not None:
+            os.environ["ENV"] = env_init
+
+    def test_get_local(self):
+        """ ensure it reads local environment vars correctly """
+        good_key = "HIVE_TESTSECRET"
+        bad_key = "HIVE_TESTSECRET_BAD"
+        sm = SecretManager("dev")
+
+        assert good_key not in os.environ
+        assert bad_key not in os.environ
+        os.environ[good_key] = "123"
+
+        assert sm.get(good_key) == "123"
+        assert sm.get(good_key.upper()) == "123"
+        assert sm.get(good_key, strict=False) == "123"
+        assert sm.get(good_key.upper(), strict=False) == "123"
+
+        with pytest.raises(KeyError):
+            sm.get(bad_key) == "123"
+
+        with pytest.raises(KeyError):
+            sm.get(bad_key.upper()) == "123"
+
+        assert sm.get(bad_key, strict=False) is None
+        assert sm.get(bad_key.upper(), strict=False) is None
+
+        del os.environ[good_key]
+
+    @pytest.mark.skip(reason="method not yet implemented")
+    def test_get_sec_mgr(self):
+        """ Anything we can test without mocking? """
+        pass
+
+    def test_make_full_key(self):
+        sm_local = SecretManager("dev")
+        sm_prod = SecretManager("prod")
+
+        test_key = "HIVE_SECRETKEY"
+
+        assert sm_local._make_full_key(test_key) == f"DEV_{test_key}"
+        assert sm_prod._make_full_key(test_key) == f"PROD_{test_key}"
+
+    def test_get(self):
+        """ test assertion on key format works """
+        sm_local = SecretManager("dev")
+        sm_prod = SecretManager("prod")
+
+        good_key = "hive_secretkey"
+        bad_key = good_key[1:]
+        assert good_key.upper() not in os.environ
+        assert bad_key.upper() not in os.environ
+        os.environ[good_key.upper()] = "123"
+
+        assert sm_local.get(good_key) == "123"
+        # not yet implemented
+        # sm_prod.get(good_key)
+
+        with pytest.raises(AssertionError):
+            sm_local.get(bad_key, strict=True)
+
+        with pytest.raises(AssertionError):
+            sm_local.get(bad_key, strict=False)
+
+        with pytest.raises(AssertionError):
+            sm_prod.get(bad_key, strict=True)
+
+        with pytest.raises(AssertionError):
+            sm_prod.get(bad_key, strict=False)
+
+        # TODO: test malformed keys
+
+        del os.environ[good_key.upper()]


### PR DESCRIPTION
This provides just what I need right now. Read secrets from environment variables (leaving space to also read from Secret Manager in the future) and facilitate querying BigQuery. Obviously I'll need updated project ids later.

Notes:
* `GBQConnection` is a clone of `RedshiftConnection`.
  * I changed `print` statements to various `logging` statements
  * I tried to test `getTablesBySchema`, but I don't have sufficient privileges. I successfully tested the rest.
  * For `getTableSchema` and `getTablesBySchema`, I updated the queries for GBQ.
* I'm not sure how authentication should work in prod, presumably with a service account.
* I added tests for `secrets`, but I'm not sure what I can substantively test in `gbq` that isn't just going to get mocked.

Questions:
* Are the `SCOPES` too broad?
* Know a better auth flow to use for `GBQConnection`?
* Should I rename anything?